### PR TITLE
New format implemented for the FPGA thresholds in the XML

### DIFF
--- a/include/BoardAddress.h
+++ b/include/BoardAddress.h
@@ -15,6 +15,7 @@ namespace PPSTimingMB
     /// Construct an object from the full address content
     inline BoardAddress(unsigned int mfec, unsigned int ccu, unsigned int i2c) :
       mfec(mfec), ccu(ccu), i2c(i2c) {;}
+
     /// Dump the full address into the output stream
     inline void Dump(std::ostream& out=std::cout) const {
       out << " * MFEC = 0x" << std::hex << mfec << std::endl
@@ -28,6 +29,14 @@ namespace PPSTimingMB
     /// I2C address
     unsigned int i2c;
   };
+  /// Comparison operator
+  inline bool operator<(const BoardAddress& a, const BoardAddress& b) {
+    if (a.mfec<b.mfec) return true;
+    else if (a.ccu<b.ccu) return true;
+    else if (a.i2c<b.i2c) return true;
+    return false;
+  }
+
 }
 
 #endif

--- a/include/NINOThresholds.h
+++ b/include/NINOThresholds.h
@@ -1,7 +1,9 @@
 #ifndef NINOThresholds_h
 #define NINOThresholds_h
 
+#include "BoardAddress.h"
 #include <iostream>
+#include <map>
 
 namespace PPSTimingMB
 {
@@ -12,19 +14,17 @@ namespace PPSTimingMB
    */
   struct NINOThresholds
   {
+    typedef std::map<BoardAddress, unsigned int> Register;
+
     /// Construct the object out of the four threshold values
-    NINOThresholds(unsigned int,unsigned int,unsigned int,unsigned int);
+    inline NINOThresholds() {;}
+    //
+    void SetValue(const BoardAddress&, unsigned int);
     /// Dump the threshold for all 4 groups into the output stream
-    void Dump(std::ostream& os=std::cout);
+    void Dump(std::ostream& os=std::cout) const;
 
     /// NINO threshold for channels 0-7
-    unsigned int group0;
-    /// NINO threshold for channels 8-15
-    unsigned int group1;
-    /// NINO threshold for channels 16-23
-    unsigned int group2;
-    /// NINO threshold for channels 24-31
-    unsigned int group3;
+    Register thresholds;
   };
 }
 

--- a/include/XMLHandler.h
+++ b/include/XMLHandler.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <sstream>
 #include <map>
+#include <regex>
 
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/util/PlatformUtils.hpp>
@@ -49,6 +50,8 @@ namespace PPSTimingMB
       std::string GetProperty(const char* name);
       /// Retrieve the (unsigned integer) value associated with a key
       unsigned int GetUIntProperty(const char* name);
+      std::map<std::string,std::string> GetStructuredProperty(const char* name);
+      std::pair<BoardAddress, unsigned int> GetNINOThresholdValue(const char* name);
      private:
       std::map<std::string,std::string> fMap;
     };
@@ -72,7 +75,7 @@ namespace PPSTimingMB
     bool ReadRegister(std::string, TDCSetup* s, const BoardAddress& addr);
 
     /// Extract a XML output of a NINO thresholds register
-    inline std::string WriteRegister(const NINOThresholds& n, unsigned int mfec, unsigned int ccu, unsigned int i2c) { return WriteRegister(n, BoardAddress(mfec, ccu, i2c)); }
+    inline std::string WriteRegister(const NINOThresholds& n, unsigned int mfec, unsigned int ccu) { return WriteRegister(n, BoardAddress(mfec, ccu, 0)); }
     /// Extract a XML output of a NINO thresholds register
     std::string WriteRegister(const NINOThresholds& n, const BoardAddress& addr);
     /// Parse a NINO thresholds register out of a XML configuration file
@@ -98,20 +101,18 @@ namespace PPSTimingMB
 
     void PopulateControlRegister(const TDCControl& c, const BoardAddress&);
     void PopulateSetupRegister(const TDCSetup& s, const BoardAddress&);
-    void PopulateNINOThresholds(const NINOThresholds& n, const BoardAddress&);
+    void PopulateNINOThresholds(const NINOThresholds& n);
 
-    void AddProperty(DOMElement* elem, const char*, const char*);
-    void AddProperty(DOMElement* elem, const char* name, unsigned int value) {
+    DOMNode* AddProperty(DOMNode* elem, const char*, const char*);
+    DOMNode* AddProperty(DOMNode* elem, const char* name, unsigned int value) {
       std::ostringstream os; os << value;
-      AddProperty(elem, name, os.str().c_str());
+      return AddProperty(elem, name, os.str().c_str());
     }
     void SetAddressAttributes(DOMElement* elem, const BoardAddress&);
     std::string GetProperty(const char* name);
     unsigned int GetUIntProperty(const char* name);
     std::string XMLString();
     std::vector<PropertiesMap> ParseRegister(std::string, const BoardAddress&);
-    /*static DOMImplementation* fImpl;
-    static DOMDocument* fDocument;*/
     DOMElement* fROOT;
     DOMImplementation* fImpl;
     DOMDocument* fDocument;

--- a/src/NINOThresholds.cpp
+++ b/src/NINOThresholds.cpp
@@ -2,17 +2,18 @@
 
 namespace PPSTimingMB
 {
-  NINOThresholds::NINOThresholds(unsigned int g0, unsigned int g1, unsigned int g2, unsigned int g3) :
-      group0(g0), group1(g1), group2(g2), group3(g3)
-  {}
+  void
+  NINOThresholds::SetValue(const BoardAddress& addr, unsigned int value)
+  {
+    thresholds[addr] = value;
+  }
 
   void
-  NINOThresholds::Dump(std::ostream& out)
+  NINOThresholds::Dump(std::ostream& out) const
   {
-    out << "NINO Thresholds:" << std::endl
-        << " * group 0 (ch.  0- 7): " << group0 << std::endl
-        << " * group 1 (ch.  8-15): " << group1 << std::endl
-        << " * group 2 (ch. 16-23): " << group2 << std::endl
-        << " * group 3 (ch. 24-31): " << group3 << std::endl;
+    out << "NINO Thresholds:" << std::endl;
+    for (Register::const_iterator it=thresholds.begin(); it!=thresholds.end(); it++) {
+      out << " * I2C address: " << it->first.i2c << " --> value: " << it->second << std::endl;
+    }
   }
 }

--- a/test/test_input_multipleregisters_multiplehptdcs.xml
+++ b/test/test_input_multipleregisters_multiplehptdcs.xml
@@ -49,10 +49,11 @@
     <reject_count_offset>0</reject_count_offset>
     <tdc_id>0</tdc_id>
   </TDCSetup>
-  <NINOThresholds ccu="0x0002" i2c="0x0001" mfec="0x0001">
-    <group0>10</group0>
-    <group1>20</group1>
-    <group2>30</group2>
-    <group3>40</group3>
+  
+  <NINOThresholds>
+    <group0 ccu="0x0003" i2c="0x0001" mfec="0x0001">10</group0>
+    <group1 ccu="0x0003" i2c="0x0002" mfec="0x0001">20</group1>
+    <group2 ccu="0x0003" i2c="0x0003" mfec="0x0001">30</group2>
+    <group3 ccu="0x0003" i2c="0x0004" mfec="0x0001">40</group3>
   </NINOThresholds>
 </TDCRegister>

--- a/test/xml.cpp
+++ b/test/xml.cpp
@@ -14,7 +14,11 @@ int main(int argc, char* argv[])
   PPSTimingMB::TDCControl c;
   PPSTimingMB::TDCSetup s;
   //s.Dump(3);
-  PPSTimingMB::NINOThresholds n(1, 2, 3, 4); // lol, just kidding
+  PPSTimingMB::NINOThresholds n;
+  n.SetValue(PPSTimingMB::BoardAddress(1, 3, 1), 1); // lol, just kidding
+  n.SetValue(PPSTimingMB::BoardAddress(1, 3, 2), 2); // lol, just kidding
+  n.SetValue(PPSTimingMB::BoardAddress(1, 3, 3), 3); // lol, just kidding
+  n.SetValue(PPSTimingMB::BoardAddress(1, 3, 4), 4); // lol, just kidding
   n.Dump();
   PPSTimingMB::XMLHandler h; 
  


### PR DESCRIPTION
Moving from a format like:
`<NINOThresholds ccu="0x0003" i2c="0x0001" mfec="0x0001">
    <group0>1</group0>
    <group0>1</group0>
    <group0>1</group0>
    <group0>1</group0>
</NINOThresholds>`
to a format like:
`<NINOThresholds>
    <group0 ccu="0x0003" i2c="0x0001" mfec="0x0001">1</group0>
    <group1 ccu="0x0003" i2c="0x0002" mfec="0x0001">2</group1>
    <group2 ccu="0x0003" i2c="0x0003" mfec="0x0001">3</group2>
    <group3 ccu="0x0003" i2c="0x0004" mfec="0x0001">4</group3>
  </NINOThresholds>`
in XML configuration files.
